### PR TITLE
Fixed issue with cycling only 2 pages

### DIFF
--- a/iron-swipeable-pages.html
+++ b/iron-swipeable-pages.html
@@ -186,6 +186,7 @@ want to be swiped:
 
         _trackMove: function(trackData) {
           this._animatePages(trackData.dx);
+          this._moveNextPageIfNecessary(trackData.dx);
         },
 
         _trackEnd: function(trackData) {
@@ -209,6 +210,13 @@ want to be swiped:
             this._animatePages(direction ? this.offsetWidth : -this.offsetWidth);
           } else {
             this._animatePages(0);
+          }
+        },
+        
+        _moveNextPageIfNecessary: function(dx) {
+          if (this._leftCandidate === this._rightCandidate) {
+            var direction = dx > 0 ? -1 : 1;
+            this._rightCandidate.style.left = (direction * this.offsetWidth) + "px";
           }
         },
 


### PR DESCRIPTION
It used to be that when you only had two pages, the non-visible page could only ever be on the right. So when you swiped to the left you would see nothing until the swiping was over and then the page would be put in place. Now the page is put on the correct side while you swipe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/metanov/iron-swipeable-pages/8)
<!-- Reviewable:end -->
