### PR TITLE
notifyResize should be triggered only once on page change

### DIFF
--- a/iron-swipeable-pages.html
+++ b/iron-swipeable-pages.html
@@ -213,7 +213,7 @@ want to be swiped:
             this._animatePages(0);
           }
         },
-        
+
         _moveNextPageIfNecessary: function(dx) {
           if (this._leftCandidate === this._rightCandidate) {
             var direction = dx > 0 ? -1 : 1;
@@ -267,15 +267,6 @@ want to be swiped:
           // reset pages state
           this._resetPages();
           this._transitionRunning = false;
-
-          // notifyResize
-          this.async(function() {
-            var selectedPage = this.selectedItem;
-            this.resizerShouldNotify = function(element) {
-              return element == selectedPage;
-            };
-            this.notifyResize();
-          });
         },
 
         _onSelectedChanged: function(selected) {
@@ -321,6 +312,15 @@ want to be swiped:
             // finally update lastIndex
             this._lastIndex = this._valueToIndex(selected);
           }
+
+          // notifyResize
+          this.async(function() {
+            var selectedPage = this.selectedItem;
+            this.resizerShouldNotify = function(element) {
+              return element == selectedPage;
+            };
+            this.notifyResize();
+          });
         },
 
         // Element utility functions


### PR DESCRIPTION
Hi,

`notifyResize` is run in `_onTransitionEnd` function, which is listening on each page events.
So the resize event is triggered as many times as there are registered swipeable pages, which leads to unnecessary redraws of displayed page.

I moved it in the main function `_onSelectedChanged`, which is run only once when page is changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metanov/iron-swipeable-pages/11)
<!-- Reviewable:end -->
