### PR TITLE
slides are not destroyed (display:none) but taken out of the viewport…

### DIFF
--- a/iron-swipeable-pages.html
+++ b/iron-swipeable-pages.html
@@ -56,7 +56,10 @@ Note: if you are using a `<paper-drawer-panel>`, it might be wise to use the fol
       will-change: left, transform;
     }
     :host > ::content > :not(.iron-selected):not(.iron-swiping) {
-      display: none !important;
+      left:-100% !important;
+    }
+    :host > ::content > .iron-selected{
+      left:0px;
     }
   </style>
 


### PR DESCRIPTION
…. This improves performance because the slides doesnt need to be repainted again.

We were having performance issues in mobile devices due to the heavy repaint needed each time that the slide is moved to the viewport

See attached screenshots:

Before (Layer needs to be repainted)
https://www.dropbox.com/s/ibsg0ed9iwit3a3/Captura%20de%20pantalla%202016-09-01%2018.14.56.png?dl=0

After (Layer is only transformed)
https://www.dropbox.com/s/zvdtsuamwrtuv3l/Captura%20de%20pantalla%202016-09-01%2018.17.36.png?dl=0

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metanov/iron-swipeable-pages/47)

<!-- Reviewable:end -->
