### PR TITLE
Input not work inside iron-swipable-pages #55

### DIFF
--- a/iron-swipeable-pages.html
+++ b/iron-swipeable-pages.html
@@ -53,6 +53,7 @@ Note: if you are using a `<paper-drawer-panel>`, it might be wise to use the fol
       width: 100%;
       height: 100%;
       overflow-y: auto;
+      z-index: 5;
       will-change: left, transform;
     }
     :host > ::content > :not(.iron-selected):not(.iron-swiping) {


### PR DESCRIPTION
A input in the element iron-swipeable-pages was not working correctly, the problem was that it was overlaid by another part of the element, to solve the problem with the input it was necessary to add to :: host> content * a z-index.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metanov/iron-swipeable-pages/56)
<!-- Reviewable:end -->
