### PR TITLE
Fix update of _offsetWidth

### DIFF
--- a/iron-swipeable-pages.html
+++ b/iron-swipeable-pages.html
@@ -546,7 +546,7 @@ Note: if you are using a `<paper-drawer-panel>`, it might be wise to use the fol
         },
 
         _getOffsetWidth: function () {
-          this._offsetWidth || this.offsetWidth + (2 * this.padding);
+          this._offsetWidth = this._offsetWidth || this.offsetWidth + (2 * this.padding);
           return this._offsetWidth;
         },
 


### PR DESCRIPTION
`this._offsetWidth` was not updated correctly, and in certain conditions was stuck to value `0`, disabling the transition animation.